### PR TITLE
Package props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Packages
 *.egg
 *.egg-info
+.eggs/
 dist
 build
 eggs
@@ -67,6 +68,7 @@ logs
 .idea/dictionaries
 .idea/vcs.xml
 .idea/jsLibraryMappings.xml
+.vscode/
 
 # Sensitive or high-churn files:
 .idea/dataSources.ids

--- a/erc190/package.py
+++ b/erc190/package.py
@@ -14,7 +14,6 @@ class Package(object):
     def __init__(self, lockfile):
         """
         A lockfile can be:
-
         - filesystem path
         - parsed lockfile JSON
         - lockfile URI
@@ -32,3 +31,16 @@ class Package(object):
         except jsonValidationError:
             raise ValidationError
         self.package_data = package_data
+
+    def __repr__(self):
+        name = self.name
+        version = self.version
+        return "<Package {0}=={1}>".format(name, version)
+
+    @property
+    def name(self):
+        return self.package_data['package_name']
+
+    @property
+    def version(self):
+        return self.package_data['version']

--- a/tests/erc190/test_package.py
+++ b/tests/erc190/test_package.py
@@ -42,3 +42,18 @@ def test_ethpm_doesnt_instantiate_with_invalid_package(invalid_package):
 def test_ethpm_doesnt_instantiate_with_invalid_path(invalid_path):
     with pytest.raises(ValidationError):
         Package(invalid_path)
+
+
+def test_package_object_has_name_property(valid_package):
+    current_package = Package(valid_package)
+    assert current_package.name == "wallet"
+
+
+def test_package_object_has_version_property(valid_package):
+    current_package = Package(valid_package)
+    assert current_package.version == "1.0.0"
+
+
+def test_package_has_custom_str_repr(valid_package):
+    current_package = Package(valid_package)
+    assert current_package.__repr__() == "<Package wallet==1.0.0>"


### PR DESCRIPTION
### What was wrong?

The `Package` object needs the properties `name` and `version` from the supplied lockfile, and its `__repr__` function should return a unique package representation using them. The representation can eventually include `Package.hash` as discussed to ensure uniqueness.

@pipermerriam @carver I created this branch from https://github.com/pipermerriam/ethereum-erc190/pull/7, which creates the `Package` object. So that one should probably be merged first, and then I can rebase to get rid of the doubled commits you'll see here now. Otherwise, this is ready for review. Any criticism of my Python style is **very** welcome.

### How was it fixed?

All of the above exist as specified here: https://github.com/pipermerriam/ethereum-erc190/issues/6

#### Cute Animal Picture

![](https://media.giphy.com/media/vgMmIZoHbR7bi/giphy.gif)
